### PR TITLE
Added a new static method areOfSameType() to Validators

### DIFF
--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
@@ -416,21 +416,22 @@ public class Validators
      *
      * @param <T>
      *            the enum-type tag's class object
-     * @param one
+     * @param firstTaggable
      *            one taggable we are comparing
-     * @param two
+     * @param secondTaggable
      *            the other taggable we are comparing against
      * @param type
      *            the class of the enum-type tag we are looking for
-     * @return true if the tag exists in one AND two, AND the value of one is equal to the value of
-     *         two.
+     * @return true if the tag exists in firstTaggable AND secondTaggable, AND the value of
+     *         firstTaggable is equal to the value of secondTaggable.
      */
-    public static <T extends Enum<T>> boolean areOfSameType(final Taggable one, final Taggable two,
-            final Class<T> type)
+    public static <T extends Enum<T>> boolean areOfSameType(final Taggable firstTaggable,
+            final Taggable secondTaggable, final Class<T> type)
     {
         final String key = findTagNameIn(type);
 
-        return one.getTag(key).flatMap(oneTag -> two.getTag(key).map(oneTag::equals)).orElse(false);
+        return firstTaggable.getTag(key)
+                .flatMap(oneTag -> secondTaggable.getTag(key).map(oneTag::equals)).orElse(false);
     }
 
     /**

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
@@ -411,7 +411,7 @@ public class Validators
     }
 
     /**
-     * Use this method to check if a tag exists on two {@link Taggable} objects, and those values
+     * Use this method to check if a tag exists in two {@link Taggable} objects, and those values
      * are the same.
      *
      * @param <T>
@@ -425,7 +425,7 @@ public class Validators
      * @return true if the tag exists in firstTaggable AND secondTaggable, AND the value of
      *         firstTaggable is equal to the value of secondTaggable.
      */
-    public static <T extends Enum<T>> boolean areOfSameType(final Taggable firstTaggable,
+    public static <T extends Enum<T>> boolean isOfSameType(final Taggable firstTaggable,
             final Taggable secondTaggable, final Class<T> type)
     {
         final String key = findTagNameIn(type);

--- a/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
+++ b/src/main/java/org/openstreetmap/atlas/tags/annotations/validation/Validators.java
@@ -411,6 +411,29 @@ public class Validators
     }
 
     /**
+     * Use this method to check if a tag exists on two {@link Taggable} objects, and those values
+     * are the same.
+     *
+     * @param <T>
+     *            the enum-type tag's class object
+     * @param one
+     *            one taggable we are comparing
+     * @param two
+     *            the other taggable we are comparing against
+     * @param type
+     *            the class of the enum-type tag we are looking for
+     * @return true if the tag exists in one AND two, AND the value of one is equal to the value of
+     *         two.
+     */
+    public static <T extends Enum<T>> boolean areOfSameType(final Taggable one, final Taggable two,
+            final Class<T> type)
+    {
+        final String key = findTagNameIn(type);
+
+        return one.getTag(key).flatMap(oneTag -> two.getTag(key).map(oneTag::equals)).orElse(false);
+    }
+
+    /**
      * Convenience method for creating the localized name of a tag if and only if tagType is a Tag
      * and the TagKey is localizable
      *

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/ValidatorsHasValuesForTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/ValidatorsHasValuesForTestCase.java
@@ -8,6 +8,7 @@ import org.openstreetmap.atlas.tags.HighwayTag;
 import org.openstreetmap.atlas.tags.NaturalTag;
 import org.openstreetmap.atlas.tags.Taggable;
 import org.openstreetmap.atlas.tags.WaterTag;
+import org.openstreetmap.atlas.tags.WaterwayTag;
 import org.openstreetmap.atlas.tags.names.NameTag;
 import org.openstreetmap.atlas.utilities.testing.TestTaggable;
 
@@ -104,5 +105,33 @@ public class ValidatorsHasValuesForTestCase
         Assert.assertFalse(
                 Validators.hasValuesFor(new TestTaggable(WaterTag.CANAL, NaturalTag.WATER),
                         NaturalTag.class, HighwayTag.class, WaterTag.class));
+    }
+
+    @Test
+    public void keyPresentDifferentValues()
+    {
+        Assert.assertFalse(Validators.areOfSameType(new TestTaggable(HighwayTag.BUS_STOP),
+                new TestTaggable(HighwayTag.CYCLEWAY), HighwayTag.class));
+    }
+
+    @Test
+    public void keyPresentSameValue()
+    {
+        Assert.assertTrue(Validators.areOfSameType(new TestTaggable(WaterTag.LAKE),
+                new TestTaggable(WaterTag.LAKE), WaterTag.class));
+    }
+
+    @Test
+    public void oneMissingKey()
+    {
+        Assert.assertFalse(Validators.areOfSameType(new TestTaggable(WaterTag.CANAL),
+                new TestTaggable(WaterwayTag.CANAL), WaterTag.class));
+    }
+
+    @Test
+    public void twoMissingKeys()
+    {
+        Assert.assertFalse(Validators.areOfSameType(new TestTaggable(WaterwayTag.CANAL),
+                new TestTaggable(WaterwayTag.CANAL), WaterTag.class));
     }
 }

--- a/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/ValidatorsHasValuesForTestCase.java
+++ b/src/test/java/org/openstreetmap/atlas/tags/annotations/validation/ValidatorsHasValuesForTestCase.java
@@ -110,28 +110,28 @@ public class ValidatorsHasValuesForTestCase
     @Test
     public void keyPresentDifferentValues()
     {
-        Assert.assertFalse(Validators.areOfSameType(new TestTaggable(HighwayTag.BUS_STOP),
+        Assert.assertFalse(Validators.isOfSameType(new TestTaggable(HighwayTag.BUS_STOP),
                 new TestTaggable(HighwayTag.CYCLEWAY), HighwayTag.class));
     }
 
     @Test
     public void keyPresentSameValue()
     {
-        Assert.assertTrue(Validators.areOfSameType(new TestTaggable(WaterTag.LAKE),
+        Assert.assertTrue(Validators.isOfSameType(new TestTaggable(WaterTag.LAKE),
                 new TestTaggable(WaterTag.LAKE), WaterTag.class));
     }
 
     @Test
     public void oneMissingKey()
     {
-        Assert.assertFalse(Validators.areOfSameType(new TestTaggable(WaterTag.CANAL),
+        Assert.assertFalse(Validators.isOfSameType(new TestTaggable(WaterTag.CANAL),
                 new TestTaggable(WaterwayTag.CANAL), WaterTag.class));
     }
 
     @Test
     public void twoMissingKeys()
     {
-        Assert.assertFalse(Validators.areOfSameType(new TestTaggable(WaterwayTag.CANAL),
+        Assert.assertFalse(Validators.isOfSameType(new TestTaggable(WaterwayTag.CANAL),
                 new TestTaggable(WaterwayTag.CANAL), WaterTag.class));
     }
 }


### PR DESCRIPTION
### Description:

This adds an extra utility function `areOfSameType` to the Validators class to compare two `Taggable`s to each other. Given a tag type, this function returns true if both of the `Taggable`s have a value for that tag type, and the values are the same.

### Potential Impact:

None -- just a new function that downstream libraries can use!

### Unit Test Approach:

Added some unit tests.

### Test Results:

All unit tests pass.

------

In doubt: [Contributing Guidelines](CONTRIBUTING.md)
